### PR TITLE
Adding lib octonode to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "electron": "^1.4.1"
+  },
+  "dependencies": {
+    "octonode": "latest"
   }
 }


### PR DESCRIPTION
Adding octonode instead of node-github because it seems better. In reference to issue #2 